### PR TITLE
Feature/#90 새로고침이 필요한 화면에 스와이프 리프레시 구현

### DIFF
--- a/WhatCampus/composeApp/src/commonMain/kotlin/core/designsystem/components/WhatCamPullToRefreshContainer.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/core/designsystem/components/WhatCamPullToRefreshContainer.kt
@@ -1,6 +1,7 @@
 package core.designsystem.components
 
-import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
 import androidx.compose.material3.pulltorefresh.PullToRefreshState
@@ -11,13 +12,16 @@ import core.designsystem.theme.WhatcamTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun BoxScope.WhatCamPullToRefreshContainer(
+fun WhatCamPullToRefreshContainer(
+    modifier: Modifier = Modifier,
     refreshState: PullToRefreshState,
 ) {
-    PullToRefreshContainer(
-        state = refreshState,
-        modifier = Modifier.align(Alignment.TopCenter),
-        containerColor = WhatcamTheme.colors.primaryContainer,
-        contentColor = WhatcamTheme.colors.primary,
-    )
+    Box(modifier = modifier.fillMaxWidth()) {
+        PullToRefreshContainer(
+            state = refreshState,
+            modifier = Modifier.align(Alignment.TopCenter),
+            containerColor = WhatcamTheme.colors.primaryContainer,
+            contentColor = WhatcamTheme.colors.primary,
+        )
+    }
 }

--- a/WhatCampus/composeApp/src/commonMain/kotlin/core/designsystem/components/WhatCamPullToRefreshContainer.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/core/designsystem/components/WhatCamPullToRefreshContainer.kt
@@ -1,0 +1,23 @@
+package core.designsystem.components
+
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
+import androidx.compose.material3.pulltorefresh.PullToRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import core.designsystem.theme.WhatcamTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BoxScope.WhatCamPullToRefreshContainer(
+    refreshState: PullToRefreshState,
+) {
+    PullToRefreshContainer(
+        state = refreshState,
+        modifier = Modifier.align(Alignment.TopCenter),
+        containerColor = WhatcamTheme.colors.primaryContainer,
+        contentColor = WhatcamTheme.colors.primary,
+    )
+}

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/app/components/WhatcamNavHost.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/app/components/WhatcamNavHost.kt
@@ -106,12 +106,12 @@ private fun SharedFlow<UniversityUiEvent>.collectUniversityUiEvent(
     LaunchedEffect(this) {
         collectLatest { uiEvent ->
             when (uiEvent) {
-                is UniversityUiEvent.UniversityLoadFailed -> onShowSnackbar(
+                UniversityUiEvent.UNIVERSITY_LOAD_FAILED -> onShowSnackbar(
                     universityLoadFailedMessage,
                     null
                 )
 
-                is UniversityUiEvent.UserSaveSuccess -> {
+                UniversityUiEvent.USER_SAVE_SUCCESS -> {
                     onShowSnackbar(userSaveSuccessMessage, null)
                     navigator.navigateMain(popUpTargetRoute = MainRoute.OnboardingRoute)
                 }

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/bookmark/BookmarkScreen.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/bookmark/BookmarkScreen.kt
@@ -1,15 +1,20 @@
 package feature.bookmark
 
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import core.common.extensions.collectAsStateMultiplatform
 import core.common.util.logScreenEvent
+import core.designsystem.components.WhatCamPullToRefreshContainer
 import core.designsystem.components.dialog.WhatcamDialog
 import core.designsystem.components.dialog.rememberDialogState
 import core.di.koinViewModel
@@ -17,7 +22,8 @@ import core.model.Notice
 import feature.bookmark.components.BookmarkList
 import feature.bookmark.components.BookmarkTopBar
 import feature.bookmark.components.EmptyBookmarkScreen
-import feature.bookmark.model.BookmarkUiState
+import feature.bookmark.model.BookmarkUiEvent
+import kotlinx.coroutines.flow.collectLatest
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import whatcampus.composeapp.generated.resources.Res
@@ -25,68 +31,52 @@ import whatcampus.composeapp.generated.resources.bookmark_delete_dialog_message
 import whatcampus.composeapp.generated.resources.bookmark_delete_dialog_title
 import whatcampus.composeapp.generated.resources.ic_alert
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun BookmarkScreen(
     modifier: Modifier = Modifier,
     viewModel: BookmarkViewModel = koinViewModel(),
     onNoticeClick: (Notice) -> Unit,
 ) {
+    logScreenEvent(screenName = "BookmarkScreen")
+
     val uiState by viewModel.uiState.collectAsStateMultiplatform()
     var isEditMode by rememberSaveable { mutableStateOf(false) }
 
-    logScreenEvent(screenName = "BookmarkScreen")
-
-    BookmarkScreen(
-        modifier = modifier,
-        onClickEdit = { isEditMode = true },
-        onClickCancel = {
-            isEditMode = false
-            viewModel.clearMarkedNoticesForDelete()
-        },
-        onClickSelectAll = {
-            if (uiState.isAllNoticesMarkedForDelete) {
-                viewModel.clearMarkedNoticesForDelete()
-            } else {
-                viewModel.markAllNoticesForDelete()
-            }
-        },
-        onClickUnbookmark = {
-            isEditMode = false
-            viewModel.unbookmarkNotices()
-        },
-        isEditMode = isEditMode,
-        isAllSelected = uiState.isAllNoticesMarkedForDelete,
-        onClickNotice = onNoticeClick,
-        onClickNoticeForDelete = viewModel::markBookmarkForDelete,
-        uiState = uiState,
-    )
-}
-
-@Composable
-private fun BookmarkScreen(
-    modifier: Modifier = Modifier,
-    onClickEdit: () -> Unit,
-    onClickCancel: () -> Unit,
-    onClickSelectAll: () -> Unit,
-    onClickUnbookmark: () -> Unit,
-    isEditMode: Boolean,
-    isAllSelected: Boolean,
-    onClickNotice: (Notice) -> Unit,
-    onClickNoticeForDelete: (Notice) -> Unit,
-    uiState: BookmarkUiState,
-) {
     val dialogState = rememberDialogState()
 
+    val refreshState = rememberPullToRefreshState()
+    if (refreshState.isRefreshing) {
+        viewModel.fetchBookmarkedNotices()
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.uiEvent.collectLatest { uiEvent ->
+            when (uiEvent) {
+                BookmarkUiEvent.NOTICE_FETCHED -> refreshState.endRefresh()
+            }
+        }
+    }
+
     Scaffold(
-        modifier = modifier,
+        modifier = modifier.nestedScroll(refreshState.nestedScrollConnection),
         topBar = {
             BookmarkTopBar(
-                onClickEdit = onClickEdit,
-                onClickCancel = onClickCancel,
-                onClickSelectAll = onClickSelectAll,
+                onClickEdit = { isEditMode = true },
+                onClickCancel = {
+                    isEditMode = false
+                    viewModel.clearMarkedNoticesForDelete()
+                },
+                onClickSelectAll = {
+                    if (uiState.isAllNoticesMarkedForDelete) {
+                        viewModel.clearMarkedNoticesForDelete()
+                    } else {
+                        viewModel.markAllNoticesForDelete()
+                    }
+                },
                 onClickUnbookmark = dialogState::showDialog,
                 isEditMode = isEditMode,
-                isAllSelected = isAllSelected,
+                isAllSelected = uiState.isAllNoticesMarkedForDelete,
                 isShowActions = !uiState.isEmptyBookmark,
             )
         },
@@ -97,8 +87,8 @@ private fun BookmarkScreen(
             BookmarkList(
                 paddingValues = paddingValues,
                 uiState = uiState,
-                onClickNotice = onClickNotice,
-                onClickNoticeForDelete = onClickNoticeForDelete,
+                onClickNotice = onNoticeClick,
+                onClickNoticeForDelete = viewModel::markBookmarkForDelete,
                 isEditMode = isEditMode
             )
         }
@@ -109,11 +99,17 @@ private fun BookmarkScreen(
                 message = stringResource(Res.string.bookmark_delete_dialog_message),
                 icon = painterResource(Res.drawable.ic_alert),
                 onConfirmClick = {
-                    onClickUnbookmark()
+                    isEditMode = false
+                    viewModel.unbookmarkNotices()
                     dialogState.hideDialog()
                 },
                 onDismissClick = dialogState::hideDialog,
             )
         }
+
+        WhatCamPullToRefreshContainer(
+            modifier = Modifier.padding(paddingValues),
+            refreshState = refreshState,
+        )
     }
 }

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/bookmark/BookmarkScreen.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/bookmark/BookmarkScreen.kt
@@ -53,7 +53,7 @@ internal fun BookmarkScreen(
     LaunchedEffect(Unit) {
         viewModel.uiEvent.collectLatest { uiEvent ->
             when (uiEvent) {
-                BookmarkUiEvent.NOTICE_FETCHED -> refreshState.endRefresh()
+                BookmarkUiEvent.REFRESH_COMPLETE -> refreshState.endRefresh()
             }
         }
     }

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/bookmark/BookmarkViewModel.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/bookmark/BookmarkViewModel.kt
@@ -37,7 +37,7 @@ class BookmarkViewModel(
     fun fetchBookmarkedNotices() {
         getAllBookmarkedNotices()
             .map { bookmarkedNotices -> _uiState.update { uiState -> uiState.copy(notices = bookmarkedNotices) } }
-            .onEach { _uiEvent.emit(BookmarkUiEvent.NOTICE_FETCHED) }
+            .onEach { _uiEvent.emit(BookmarkUiEvent.REFRESH_COMPLETE) }
             .launchIn(viewModelScope)
     }
 

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/bookmark/BookmarkViewModel.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/bookmark/BookmarkViewModel.kt
@@ -5,37 +5,39 @@ import androidx.lifecycle.viewModelScope
 import core.domain.repository.NoticeRepository
 import core.domain.usecase.GetAllBookmarkedNoticesUseCase
 import core.model.Notice
+import feature.bookmark.model.BookmarkUiEvent
 import feature.bookmark.model.BookmarkUiState
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toPersistentSet
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class BookmarkViewModel(
-    getAllBookmarkedNotices: GetAllBookmarkedNoticesUseCase,
+    private val getAllBookmarkedNotices: GetAllBookmarkedNoticesUseCase,
     private val noticeRepository: NoticeRepository,
 ) : ViewModel() {
-
     private val _uiState = MutableStateFlow(BookmarkUiState())
     val uiState: StateFlow<BookmarkUiState> = _uiState.asStateFlow()
 
+    private val _uiEvent = MutableSharedFlow<BookmarkUiEvent>()
+    val uiEvent = _uiEvent.asSharedFlow()
+
     init {
+        fetchBookmarkedNotices()
+    }
+
+    fun fetchBookmarkedNotices() {
         getAllBookmarkedNotices()
-            .map { bookmarkedNotices ->
-                _uiState.value = _uiState.value.copy(notices = bookmarkedNotices)
-            }
-            .stateIn(
-                scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5000),
-                initialValue = BookmarkUiState()
-            )
+            .map { bookmarkedNotices -> _uiState.update { uiState -> uiState.copy(notices = bookmarkedNotices) } }
+            .onEach { _uiEvent.emit(BookmarkUiEvent.NOTICE_FETCHED) }
             .launchIn(viewModelScope)
     }
 

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/bookmark/model/BookmarkUiEvent.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/bookmark/model/BookmarkUiEvent.kt
@@ -1,0 +1,5 @@
+package feature.bookmark.model
+
+enum class BookmarkUiEvent {
+    NOTICE_FETCHED
+}

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/bookmark/model/BookmarkUiEvent.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/bookmark/model/BookmarkUiEvent.kt
@@ -1,5 +1,5 @@
 package feature.bookmark.model
 
 enum class BookmarkUiEvent {
-    NOTICE_FETCHED
+    REFRESH_COMPLETE
 }

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/notice/NoticeScreen.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/notice/NoticeScreen.kt
@@ -8,21 +8,29 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import core.common.extensions.collectAsStateMultiplatform
 import core.common.extensions.collectUiEvent
 import core.common.util.logScreenEvent
+import core.designsystem.components.WhatCamPullToRefreshContainer
 import core.di.koinViewModel
 import core.model.Notice
 import feature.notice.components.NoticeCategoryBar
 import feature.notice.components.NoticeList
 import feature.notice.components.NoticeTopAppBar
+import feature.notice.model.NoticeUiEvent
+import kotlinx.coroutines.flow.collectLatest
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NoticeScreen(
     viewModel: NoticeViewModel = koinViewModel(),
@@ -31,10 +39,23 @@ fun NoticeScreen(
     onClickNotificationArchive: () -> Unit,
     onClickProfile: () -> Unit,
 ) {
+    logScreenEvent(screenName = "NoticeScreen")
+
     val uiState by viewModel.uiState.collectAsStateMultiplatform()
     viewModel.commonUiEvent.collectUiEvent()
 
-    logScreenEvent(screenName = "NoticeScreen")
+    val refreshState = rememberPullToRefreshState()
+    if (refreshState.isRefreshing) {
+        viewModel.fetchNotices()
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.uiEvent.collectLatest { uiEvent ->
+            when (uiEvent) {
+                NoticeUiEvent.NOTICE_FETCHED -> refreshState.endRefresh()
+            }
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -47,7 +68,9 @@ fun NoticeScreen(
         }
     ) { paddingValues ->
         Box(
-            modifier = Modifier.padding(paddingValues)
+            modifier = Modifier
+                .padding(paddingValues)
+                .nestedScroll(refreshState.nestedScrollConnection)
         ) {
             val noticeListScrollState = rememberLazyListState()
 
@@ -74,6 +97,8 @@ fun NoticeScreen(
                     onClickCategory = viewModel::selectCategory,
                 )
             }
+
+            WhatCamPullToRefreshContainer(refreshState = refreshState)
         }
     }
 }

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/notice/NoticeScreen.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/notice/NoticeScreen.kt
@@ -52,7 +52,7 @@ fun NoticeScreen(
     LaunchedEffect(Unit) {
         viewModel.uiEvent.collectLatest { uiEvent ->
             when (uiEvent) {
-                NoticeUiEvent.NOTICE_FETCHED -> refreshState.endRefresh()
+                NoticeUiEvent.REFRESH_COMPLETE -> refreshState.endRefresh()
             }
         }
     }

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/notice/NoticeViewModel.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/notice/NoticeViewModel.kt
@@ -111,7 +111,7 @@ class NoticeViewModel(
                     is Response.Failure.NetworkError -> sendNetworkErrorEvent()
                     is Response.Failure.OtherError<*> -> sendOtherErrorEvent()
                 }
-                _uiEvent.emit(NoticeUiEvent.NOTICE_FETCHED)
+                _uiEvent.emit(NoticeUiEvent.REFRESH_COMPLETE)
             }
             .launchIn(viewModelScope)
     }

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/notice/NoticeViewModel.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/notice/NoticeViewModel.kt
@@ -9,12 +9,16 @@ import core.domain.usecase.GetAllBookmarkedNoticesUseCase
 import core.domain.usecase.GetNoticesByCategoryIdUseCase
 import core.model.NoticeCategory
 import core.model.Response
+import feature.notice.model.NoticeUiEvent
 import feature.notice.model.NoticeUiState
 import feature.notice.model.NoticeWithBookmark
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emptyFlow
@@ -29,12 +33,15 @@ import kotlinx.coroutines.flow.update
 class NoticeViewModel(
     noticeRepository: NoticeRepository,
     notificationRepository: NotificationRepository,
-    getNoticesByCategoryId: GetNoticesByCategoryIdUseCase,
     userRepository: UserRepository,
-    getAllBookmarkedNotices: GetAllBookmarkedNoticesUseCase,
+    private val getNoticesByCategoryId: GetNoticesByCategoryIdUseCase,
+    private val getAllBookmarkedNotices: GetAllBookmarkedNoticesUseCase,
 ) : CommonViewModel() {
     private val _uiState: MutableStateFlow<NoticeUiState> = MutableStateFlow(NoticeUiState())
     val uiState: StateFlow<NoticeUiState> = _uiState.asStateFlow()
+
+    private val _uiEvent: MutableSharedFlow<NoticeUiEvent> = MutableSharedFlow()
+    val uiEvent: SharedFlow<NoticeUiEvent> = _uiEvent.asSharedFlow()
 
     init {
         userRepository.flowUser()
@@ -67,6 +74,10 @@ class NoticeViewModel(
             }
             .launchIn(viewModelScope)
 
+
+    }
+
+    fun fetchNotices() {
         uiState
             .flatMapLatest { state ->
                 val universityId = state.user?.universityId ?: return@flatMapLatest emptyFlow()
@@ -100,6 +111,7 @@ class NoticeViewModel(
                     is Response.Failure.NetworkError -> sendNetworkErrorEvent()
                     is Response.Failure.OtherError<*> -> sendOtherErrorEvent()
                 }
+                _uiEvent.emit(NoticeUiEvent.NOTICE_FETCHED)
             }
             .launchIn(viewModelScope)
     }

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/notice/components/NoticeList.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/notice/components/NoticeList.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -48,7 +49,7 @@ internal fun NoticeList(
     onClickItem: (Notice) -> Unit,
 ) {
     LazyColumn(
-        modifier = modifier,
+        modifier = modifier.fillMaxSize(),
         contentPadding = PaddingValues(top = 56.dp),
         state = listState,
     ) {

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/notice/model/NoticeUiEvent.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/notice/model/NoticeUiEvent.kt
@@ -1,5 +1,5 @@
 package feature.notice.model
 
 enum class NoticeUiEvent {
-    NOTICE_FETCHED
+    REFRESH_COMPLETE
 }

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/notice/model/NoticeUiEvent.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/notice/model/NoticeUiEvent.kt
@@ -1,0 +1,5 @@
+package feature.notice.model
+
+enum class NoticeUiEvent {
+    NOTICE_FETCHED
+}

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/notificationArchive/NotificationArchiveScreen.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/notificationArchive/NotificationArchiveScreen.kt
@@ -2,20 +2,27 @@ package feature.notificationArchive
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import core.common.extensions.collectAsStateMultiplatform
 import core.common.extensions.collectUiEvent
 import core.common.util.logScreenEvent
 import core.designsystem.components.LoadingScreen
+import core.designsystem.components.WhatCamPullToRefreshContainer
 import core.di.koinViewModel
 import core.model.Notification
 import feature.notificationArchive.components.NotificationArchiveList
 import feature.notificationArchive.components.NotificationArchiveTopBar
+import feature.notificationArchive.model.NotificationArchiveUiEvent
+import kotlinx.coroutines.flow.collectLatest
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NotificationArchiveScreen(
     modifier: Modifier = Modifier,
@@ -23,13 +30,23 @@ fun NotificationArchiveScreen(
     onClickBack: () -> Unit,
     onClickNewNoticeNotification: (Notification.NewNotice) -> Unit,
 ) {
+    logScreenEvent(screenName = "NotificationArchiveScreen")
+
     val uiState by viewModel.uiState.collectAsStateMultiplatform()
     viewModel.commonUiEvent.collectUiEvent()
 
-    logScreenEvent(screenName = "NotificationArchiveScreen")
+    val refreshState = rememberPullToRefreshState()
+    if (refreshState.isRefreshing) {
+        viewModel.fetchNotifications()
+    }
 
     LaunchedEffect(Unit) {
         viewModel.turnOffNewNotification()
+        viewModel.uiEvent.collectLatest { uiEvent ->
+            when (uiEvent) {
+                NotificationArchiveUiEvent.NOTICE_FETCHED -> refreshState.endRefresh()
+            }
+        }
     }
 
     Scaffold(
@@ -42,12 +59,19 @@ fun NotificationArchiveScreen(
         }
 
         NotificationArchiveList(
-            modifier = modifier.padding(paddingValues),
+            modifier = modifier
+                .padding(paddingValues)
+                .nestedScroll(refreshState.nestedScrollConnection),
             notifications = uiState.notifications,
             onClickNewNoticeNotification = { newNoticeNotification ->
                 viewModel.readNotification(notificationId = newNoticeNotification.id)
                 onClickNewNoticeNotification(newNoticeNotification)
             },
+        )
+
+        WhatCamPullToRefreshContainer(
+            modifier = modifier.padding(paddingValues),
+            refreshState = refreshState
         )
     }
 }

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/notificationArchive/NotificationArchiveScreen.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/notificationArchive/NotificationArchiveScreen.kt
@@ -44,7 +44,7 @@ fun NotificationArchiveScreen(
         viewModel.turnOffNewNotification()
         viewModel.uiEvent.collectLatest { uiEvent ->
             when (uiEvent) {
-                NotificationArchiveUiEvent.NOTICE_FETCHED -> refreshState.endRefresh()
+                NotificationArchiveUiEvent.REFRESH_COMPLETE -> refreshState.endRefresh()
             }
         }
     }

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/notificationArchive/NotificationArchiveViewModel.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/notificationArchive/NotificationArchiveViewModel.kt
@@ -6,11 +6,18 @@ import core.domain.repository.NotificationRepository
 import core.domain.repository.UserRepository
 import core.model.Notification
 import core.model.Response
+import feature.notificationArchive.model.NotificationArchiveUiEvent
 import feature.notificationArchive.model.NotificationArchiveUiState
 import kotlinx.collections.immutable.PersistentList
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -18,9 +25,11 @@ class NotificationArchiveViewModel(
     private val userRepository: UserRepository,
     private val notificationRepository: NotificationRepository,
 ) : CommonViewModel() {
-
     private val _uiState = MutableStateFlow(NotificationArchiveUiState(isLoading = true))
     val uiState = _uiState.asStateFlow()
+
+    private val _uiEvent = MutableSharedFlow<NotificationArchiveUiEvent>()
+    val uiEvent = _uiEvent.asSharedFlow()
 
     init {
         viewModelScope.launch {
@@ -35,20 +44,38 @@ class NotificationArchiveViewModel(
     }
 
     fun readNotification(notificationId: Long) {
-        viewModelScope.launch {
-            val user = userRepository.flowUser().firstOrNull() ?: return@launch sendOtherErrorEvent()
-
-            notificationRepository.readNotification(
-                userId = user.userId,
-                notificationId = notificationId,
-            )
-            fetchNotifications()
-        }
+        userRepository.flowUser()
+            .onEach { user ->
+                if (user == null) {
+                    sendOtherErrorEvent()
+                    _uiEvent.emit(NotificationArchiveUiEvent.NOTICE_FETCHED)
+                }
+            }
+            .filterNotNull()
+            .onEach { user ->
+                notificationRepository.readNotification(
+                    userId = user.userId,
+                    notificationId = notificationId,
+                )
+            }
+            .onEach { fetchNotifications() }
+            .launchIn(viewModelScope)
     }
 
-    private suspend fun fetchNotifications() {
-        val user = userRepository.flowUser().firstOrNull() ?: return sendOtherErrorEvent()
-        notificationRepository.flowNotifications(userId = user.userId).collect(::handleResponse)
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun fetchNotifications() {
+        userRepository.flowUser()
+            .onEach { user ->
+                if (user == null) {
+                    sendOtherErrorEvent()
+                    _uiEvent.emit(NotificationArchiveUiEvent.NOTICE_FETCHED)
+                }
+            }
+            .filterNotNull()
+            .flatMapLatest { user -> notificationRepository.flowNotifications(userId = user.userId) }
+            .onEach(::handleResponse)
+            .onEach { _uiEvent.emit(NotificationArchiveUiEvent.NOTICE_FETCHED) }
+            .launchIn(viewModelScope)
     }
 
     private suspend fun handleResponse(response: Response<PersistentList<Notification>>) {

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/notificationArchive/NotificationArchiveViewModel.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/notificationArchive/NotificationArchiveViewModel.kt
@@ -48,7 +48,7 @@ class NotificationArchiveViewModel(
             .onEach { user ->
                 if (user == null) {
                     sendOtherErrorEvent()
-                    _uiEvent.emit(NotificationArchiveUiEvent.NOTICE_FETCHED)
+                    _uiEvent.emit(NotificationArchiveUiEvent.REFRESH_COMPLETE)
                 }
             }
             .filterNotNull()
@@ -68,13 +68,13 @@ class NotificationArchiveViewModel(
             .onEach { user ->
                 if (user == null) {
                     sendOtherErrorEvent()
-                    _uiEvent.emit(NotificationArchiveUiEvent.NOTICE_FETCHED)
+                    _uiEvent.emit(NotificationArchiveUiEvent.REFRESH_COMPLETE)
                 }
             }
             .filterNotNull()
             .flatMapLatest { user -> notificationRepository.flowNotifications(userId = user.userId) }
             .onEach(::handleResponse)
-            .onEach { _uiEvent.emit(NotificationArchiveUiEvent.NOTICE_FETCHED) }
+            .onEach { _uiEvent.emit(NotificationArchiveUiEvent.REFRESH_COMPLETE) }
             .launchIn(viewModelScope)
     }
 

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/notificationArchive/model/NotificationArchiveUiEvent.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/notificationArchive/model/NotificationArchiveUiEvent.kt
@@ -1,5 +1,5 @@
 package feature.notificationArchive.model
 
 enum class NotificationArchiveUiEvent {
-    NOTICE_FETCHED
+    REFRESH_COMPLETE
 }

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/notificationArchive/model/NotificationArchiveUiEvent.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/notificationArchive/model/NotificationArchiveUiEvent.kt
@@ -1,0 +1,5 @@
+package feature.notificationArchive.model
+
+enum class NotificationArchiveUiEvent {
+    NOTICE_FETCHED
+}

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/profile/subscreen/noticeCategory/NoticeCategoryScreen.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/profile/subscreen/noticeCategory/NoticeCategoryScreen.kt
@@ -44,7 +44,7 @@ internal fun NoticeCategoryScreen(
     LaunchedEffect(Unit) {
         viewModel.uiEvent.collectLatest { uiEvent ->
             when (uiEvent) {
-                NoticeCategoryUiEvent.NOTICE_FETCHED -> refreshState.endRefresh()
+                NoticeCategoryUiEvent.REFRESH_COMPLETE -> refreshState.endRefresh()
             }
         }
     }

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/profile/subscreen/noticeCategory/NoticeCategoryScreen.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/profile/subscreen/noticeCategory/NoticeCategoryScreen.kt
@@ -1,21 +1,29 @@
 package feature.profile.subscreen.noticeCategory
 
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
 import core.common.extensions.collectAsStateMultiplatform
 import core.common.extensions.collectUiEvent
 import core.designsystem.components.NoticeCategoryList
+import core.designsystem.components.WhatCamPullToRefreshContainer
 import core.di.koinViewModel
 import feature.profile.subscreen.noticeCategory.components.NoticeCategoryTopBar
+import feature.profile.subscreen.noticeCategory.model.NoticeCategoryUiEvent
+import kotlinx.coroutines.flow.collectLatest
 import org.jetbrains.compose.resources.stringResource
 import whatcampus.composeapp.generated.resources.Res
 import whatcampus.composeapp.generated.resources.notice_category_saved_action_label
 import whatcampus.composeapp.generated.resources.notice_category_saved_message
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun NoticeCategoryScreen(
     modifier: Modifier = Modifier,
@@ -26,10 +34,23 @@ internal fun NoticeCategoryScreen(
     val uiState by viewModel.uiState.collectAsStateMultiplatform()
     val savedMessage = stringResource(Res.string.notice_category_saved_message)
     val savedActionLabel = stringResource(Res.string.notice_category_saved_action_label)
+
+    val refreshState = rememberPullToRefreshState()
+    if (refreshState.isRefreshing) {
+        viewModel.fetchNoticeCategories()
+    }
+
     viewModel.commonUiEvent.collectUiEvent()
+    LaunchedEffect(Unit) {
+        viewModel.uiEvent.collectLatest { uiEvent ->
+            when (uiEvent) {
+                NoticeCategoryUiEvent.NOTICE_FETCHED -> refreshState.endRefresh()
+            }
+        }
+    }
 
     Scaffold(
-        modifier = modifier,
+        modifier = modifier.nestedScroll(refreshState.nestedScrollConnection),
         topBar = {
             NoticeCategoryTopBar(
                 onClickBack = onClickBack,
@@ -47,6 +68,11 @@ internal fun NoticeCategoryScreen(
             noticeCategories = uiState.noticeCategories,
             subscribedNoticeCategories = uiState.subscribedNoticeCategories,
             onClickCategory = viewModel::toggleNoticeCategory,
+        )
+
+        WhatCamPullToRefreshContainer(
+            modifier = Modifier.padding(paddingValues),
+            refreshState = refreshState
         )
     }
 }

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/profile/subscreen/noticeCategory/NoticeCategoryViewModel.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/profile/subscreen/noticeCategory/NoticeCategoryViewModel.kt
@@ -51,7 +51,7 @@ class NoticeCategoryViewModel(
                     handleNoticeCategoriesResponse(subscribedNoticeCategoriesResponse, noticeCategoriesResponse, user)
                 }
             }
-            .onEach { _uiEvent.emit(NoticeCategoryUiEvent.NOTICE_FETCHED) }
+            .onEach { _uiEvent.emit(NoticeCategoryUiEvent.REFRESH_COMPLETE) }
             .launchIn(viewModelScope)
     }
 

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/profile/subscreen/noticeCategory/NoticeCategoryViewModel.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/profile/subscreen/noticeCategory/NoticeCategoryViewModel.kt
@@ -8,28 +8,39 @@ import core.domain.usecase.SubscribeNoticeCategoriesUseCase
 import core.model.NoticeCategory
 import core.model.Response
 import core.model.User
+import feature.profile.subscreen.noticeCategory.model.NoticeCategoryUiEvent
 import feature.profile.subscreen.noticeCategory.model.NoticeCategoryUiState
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class NoticeCategoryViewModel(
-    noticeRepository: NoticeRepository,
-    userRepository: UserRepository,
+    private val noticeRepository: NoticeRepository,
+    private val userRepository: UserRepository,
     private val subscribeNoticeCategories: SubscribeNoticeCategoriesUseCase,
 ) : CommonViewModel() {
     private val _uiState = MutableStateFlow(NoticeCategoryUiState())
     val uiState: StateFlow<NoticeCategoryUiState> = _uiState.asStateFlow()
 
+    private val _uiEvent = MutableSharedFlow<NoticeCategoryUiEvent>()
+    val uiEvent = _uiEvent.asSharedFlow()
+
     init {
+        fetchNoticeCategories()
+    }
+
+    fun fetchNoticeCategories() {
         userRepository.flowUser()
             .filterNotNull()
             .flatMapLatest { user ->
@@ -40,8 +51,8 @@ class NoticeCategoryViewModel(
                     handleNoticeCategoriesResponse(subscribedNoticeCategoriesResponse, noticeCategoriesResponse, user)
                 }
             }
+            .onEach { _uiEvent.emit(NoticeCategoryUiEvent.NOTICE_FETCHED) }
             .launchIn(viewModelScope)
-
     }
 
     private suspend fun NoticeCategoryViewModel.handleNoticeCategoriesResponse(

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/profile/subscreen/noticeCategory/model/NoticeCategoryUiEvent.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/profile/subscreen/noticeCategory/model/NoticeCategoryUiEvent.kt
@@ -1,5 +1,5 @@
-package feature.noticeCategory.model
+package feature.profile.subscreen.noticeCategory.model
 
-sealed interface NoticeCategoryUiEvent {
-    data object NavigateToOnboarding : NoticeCategoryUiEvent
+enum class NoticeCategoryUiEvent {
+    NOTICE_FETCHED
 }

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/profile/subscreen/noticeCategory/model/NoticeCategoryUiEvent.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/profile/subscreen/noticeCategory/model/NoticeCategoryUiEvent.kt
@@ -1,5 +1,5 @@
 package feature.profile.subscreen.noticeCategory.model
 
 enum class NoticeCategoryUiEvent {
-    NOTICE_FETCHED
+    REFRESH_COMPLETE
 }

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/university/UniversityViewModel.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/university/UniversityViewModel.kt
@@ -64,7 +64,7 @@ class UniversityViewModel(
                 }
 
                 Response.Failure.NetworkError -> sendNetworkErrorEvent()
-                else -> _uiEvent.emit(UniversityUiEvent.UniversityLoadFailed)
+                else -> _uiEvent.emit(UniversityUiEvent.UNIVERSITY_LOAD_FAILED)
             }
         }
 
@@ -79,7 +79,7 @@ class UniversityViewModel(
                         )
                     }
 
-                    else -> _uiEvent.emit(UniversityUiEvent.UniversityLoadFailed)
+                    else -> _uiEvent.emit(UniversityUiEvent.UNIVERSITY_LOAD_FAILED)
                 }
             }
             .launchIn(viewModelScope)
@@ -133,7 +133,7 @@ class UniversityViewModel(
             )
 
             when (userCreateResponse) {
-                is Response.Success -> _uiEvent.emit(UniversityUiEvent.UserSaveSuccess)
+                is Response.Success -> _uiEvent.emit(UniversityUiEvent.USER_SAVE_SUCCESS)
                 Response.Failure.ClientError -> sendClientErrorEvent()
                 Response.Failure.ServerError -> sendServerErrorEvent()
                 Response.Failure.NetworkError -> sendNetworkErrorEvent()

--- a/WhatCampus/composeApp/src/commonMain/kotlin/feature/university/model/UniversityUiEvent.kt
+++ b/WhatCampus/composeApp/src/commonMain/kotlin/feature/university/model/UniversityUiEvent.kt
@@ -1,6 +1,6 @@
 package feature.university.model
 
-sealed interface UniversityUiEvent {
-    data object UniversityLoadFailed : UniversityUiEvent
-    data object UserSaveSuccess : UniversityUiEvent
+enum class UniversityUiEvent {
+    UNIVERSITY_LOAD_FAILED,
+    USER_SAVE_SUCCESS,
 }


### PR DESCRIPTION
## Issue
- close #90

## 작업 내용
하기 화면에 SwipeRefresh를 구현하였습니다.
새로고침 시, 각 화면에서 표현하는 리스트 데이터를 갱신하도록 하였습니다.

- 공지 카테고리 화면
- 북마크 화면
- 공지 목록 화면
- 알림 보관함 화면

이후에 `SwipeRefreshIndicator` 를 공통으로 사용하기 위해,
designsystem 모듈에 **`WhatCamPullToRefreshContainer()`** 라는 컴포넌트를 구현하였습니다.

## 스크린샷 (선택)
Android | iOS
:--: | :--:
<img src="https://github.com/user-attachments/assets/32c6908b-4960-4511-847e-f848731a9027" width="300" /> | <img src="" width="300" />
